### PR TITLE
[ADR-255] Home screen statistics not aligned

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,8 +15,8 @@ ext {
 }
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.3"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.1"
 
     defaultConfig {
         applicationId "co.netguru.android.socialslack"

--- a/app/src/main/res/layout/dashboard_statistics_card.xml
+++ b/app/src/main/res/layout/dashboard_statistics_card.xml
@@ -6,7 +6,8 @@
     android:layout_height="match_parent"
     android:orientation="vertical"
     app:cardCornerRadius="@dimen/card_corner_radius_small"
-    app:cardElevation="@dimen/card_elevation">
+    app:cardElevation="@dimen/card_elevation"
+    tools:ignore="missingPrefix">
 
     <RelativeLayout
         android:layout_width="match_parent"
@@ -25,10 +26,11 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_above="@+id/dashboardStatisticText"
-            android:layout_marginBottom="@dimen/card_subtitle_margin"
             android:layout_alignParentEnd="true"
+            android:layout_marginBottom="@dimen/card_subtitle_margin"
             android:textColor="?attr/colorHighlight"
             android:textSize="@dimen/header_textSize"
+            app:autoSizeTextType="uniform"
             tools:text="35" />
 
         <TextView
@@ -41,6 +43,7 @@
             android:gravity="end"
             android:textColor="@color/grey"
             android:textSize="@dimen/subtitle_textSize"
+            app:autoSizeTextType="uniform"
             tools:text="total number of read messages" />
 
     </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,7 +46,7 @@
 
     <string name="messages">messages</string>
     <string name="mentions">mentions</string>
-    <string name="statistic_messages_sent">messages sent by you\non channels</string>
+    <string name="statistic_messages_sent">messages sent\nby you on channels</string>
     <string name="statistic_mentions">mentions\non channels</string>
     <string name="statistic_private_messages">total number\nof private messages</string>
     <string name="statistic_sent_private_messages">sent\nprivate messages</string>

--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -1,6 +1,6 @@
 ext {
     // Versions
-    supportLibraryVersion = '25.3.1'
+    supportLibraryVersion = '26.0.1'
     roomVersion = "1.0.0-alpha5"
     multiDexVersion = '1.0.1'
     constraintLayoutVersion = '1.0.2'


### PR DESCRIPTION
…es version. Use autosize text type for the dashboard statistics text views

[ADR-255]

### Task
<!-- Add links to JIRA task and other relevant resources -->
 - [JIRA](https://netguru.atlassian.net/browse/ADR-255)
 
### Description
<!-- Describe the solution, changes, possible problems etc. -->
- Upgrade build tools version to 26.0.1
- Upgrade support libraries version to  26.0.1
- Upgrade compile sdk version to 26
- Use autoSizeTextType uniform for the textviews in dashboard statistics
- Modify string to fit in the view

### Additional Notes (optional)
<!-- Provide any additional notes: quick tips for the reviewer, related PRs, screenshots, et al.). -->
 
### Checklist
<!-- Replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
 - [x] I am following the [code style guide](https://netguru.atlassian.net/wiki/display/ANDROID/Android+best+practices)
 - [ ] The code includes tests of new features
 - [x] The code passes static analysis
 - [x] README.md is up to date
 - [x] Version number is up to date
 - [x] ProGuard configuration files are up to date
 - [x] All temporary TODOs and FIXMEs are removed
 - [x] I have tested the solution on these devices:
  * Nexus 6P, Android 7.1.2
  * LG Zero, Android 6
  
### Merge
<!-- Mark person(s) allowed to perform merge to the target branch with [x] (can be multiple) -->
 - [x] Committer
 - [ ] Reviewer
 - [ ] Project lead